### PR TITLE
Document side panel, picker keybindings, and S3 service layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,9 @@ task dev               # run against LocalStack
 | `:`               | Command palette           |
 | `q`               | Quit                      |
 
-**Content Viewer**
+**Content Viewer / Side Panel**
+
+These keys apply in the content viewer and when the side panel is focused (press `tab` to toggle focus).
 
 | Key               | Action              |
 | ----------------- | ------------------- |
@@ -98,6 +100,20 @@ task dev               # run against LocalStack
 | `y`               | Yank to clipboard   |
 | `e`               | Open in `$EDITOR`   |
 | `n`               | Toggle line numbers |
+| `tab`             | Focus main view     |
+| `esc`             | Close panel         |
+
+**Picker** (profile, region, theme, sort, command palette)
+
+| Key               | Action              |
+| ----------------- | ------------------- |
+| `↑`/`↓`           | Navigate options    |
+| `enter`           | Select              |
+| `esc`             | Cancel              |
+| `ctrl+x`          | Clear/reset         |
+| *type*            | Fuzzy filter        |
+
+The picker ranks matches by relevance: prefix matches first, then substring, then fuzzy.
 
 ## Configuration
 

--- a/services/aws/s3.md
+++ b/services/aws/s3.md
@@ -100,6 +100,34 @@ Selections persist across filter changes — you can select items, filter, selec
 
 Buckets are automatically accessed in their correct region. LazyCloud resolves each bucket's region via `GetBucketLocation` to avoid 301 redirect errors when the bucket is in a different region than the configured client.
 
+## Service Layer
+
+`internal/aws/s3.go` implements the `S3Service` interface:
+
+```go
+type S3Service interface {
+    ListBuckets(ctx context.Context) ([]Bucket, error)
+    ListObjectsPage(ctx context.Context, bucket, prefix string, token *string) (*ObjectPage, error)
+    HeadObject(ctx context.Context, bucket, key string) (*ObjectMeta, error)
+    GetObjectContent(ctx context.Context, bucket, key string, maxBytes int64) (string, error)
+    PresignGetObject(ctx context.Context, bucket, key string, expiry time.Duration) (string, error)
+    ListAllKeys(ctx context.Context, bucket, prefix string) ([]string, error)
+    DownloadObject(ctx context.Context, bucket, key, destPath string) error
+    ListObjectVersions(ctx context.Context, bucket, key string) ([]ObjectVersion, error)
+    GetBucketProperties(ctx context.Context, bucket string) (*BucketProperties, error)
+    GetBucketRegion(ctx context.Context, bucket string) (string, error)
+    DeleteObject(ctx context.Context, bucket, key string) error
+    DeleteObjects(ctx context.Context, bucket string, keys []string) error
+    DeleteBucket(ctx context.Context, bucket string) error
+    EmptyAndDeleteBucket(ctx context.Context, bucket string) error
+    CopyObject(ctx context.Context, srcBucket, srcKey, dstBucket, dstKey string) error
+    MoveObject(ctx context.Context, srcBucket, srcKey, dstBucket, dstKey string) error
+    CreateBucket(ctx context.Context, name, region string) error
+}
+```
+
+Object listing uses paginated fetching (`ListObjectsPage`) with progressive loading. Buckets are automatically accessed in their correct region via `GetBucketRegion`. A shared `MockS3Service` in `internal/aws/awstest/` enables testing views without AWS credentials.
+
 ## LocalStack
 
 Works with LocalStack. Seed test buckets with:


### PR DESCRIPTION
## Summary

Documentation updates for previously undocumented UI features and the S3 service interface.

- **README**: Expanded "Content Viewer" section to "Content Viewer / Side Panel" with note that keys apply when panel is focused, added `tab`/`esc` keys
- **README**: Added new "Picker" keybindings section covering all picker popups (profile, region, theme, sort, command palette) — documents navigation, fuzzy filter, `ctrl+x` clear, and three-tier match ranking (prefix > contains > fuzzy)
- **S3 docs**: Added "Service Layer" section to `services/aws/s3.md` documenting the full `S3Service` interface (17 methods), matching the format used in the EC2 doc

Closes #11, closes #12