### PR TITLE
Add SSM session support for EC2 instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Only **AWS** is supported at this time. Other cloud providers may be added in th
 | Service                    | Status      | Description                                                                                                                        |
 | -------------------------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------- |
 | [S3](services/aws/s3.md)   | Implemented | Browse buckets, navigate objects, preview/download files, copy/move, versioning, presigned URLs, create/delete buckets and objects |
-| [EC2](services/aws/ec2.md) | Implemented | Browse instances, view instance details, color-coded state, copy instance ID                                                       |
+| [EC2](services/aws/ec2.md) | Implemented | Browse instances, view instance details, color-coded state, copy instance ID, SSM session connect                                  |
 
 ## Tech Stack
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -774,7 +774,7 @@ func (m Model) resolveView(n appmsg.NavigateMsg) nav.View {
 		}
 		return views.NewServiceMenu(name, features)
 	case "ec2_list":
-		return views.NewEC2List(m.ec2)
+		return views.NewEC2List(m.ec2, m.awsClient)
 	case "s3_list":
 		return views.NewS3List(m.s3, m.config.AWS.Region)
 	case "s3_objects":

--- a/internal/aws/ec2.go
+++ b/internal/aws/ec2.go
@@ -3,6 +3,9 @@ package aws
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -35,6 +38,31 @@ func (c *Client) EC2Client() *ec2.Client {
 			o.BaseEndpoint = aws.String(c.Endpoint)
 		}
 	})
+}
+
+// SSMSessionCmd returns an exec.Cmd to start an SSM session for the given instance.
+// Requires the AWS CLI and session-manager-plugin to be installed.
+// The label is displayed as a banner before the session starts (e.g. "my-server (i-abc123)").
+func (c *Client) SSMSessionCmd(instanceID, label string) *exec.Cmd {
+	args := []string{"ssm", "start-session", "--target", instanceID}
+	if c.Region != "" {
+		args = append(args, "--region", c.Region)
+	}
+	if c.Profile != "" {
+		args = append(args, "--profile", c.Profile)
+	}
+	// Build a shell command that prints a banner then execs the session
+	fullArgs := append([]string{"aws"}, args...)
+	awsCmd := strings.Join(fullArgs, " ")
+	banner := fmt.Sprintf("\033[1;36m── SSM Session: %s ──\033[0m\n", label)
+	shell := fmt.Sprintf("printf '%s' && %s", banner, awsCmd)
+	return exec.Command("sh", "-c", shell)
+}
+
+// SSMPluginAvailable returns true if the session-manager-plugin is installed.
+func SSMPluginAvailable() bool {
+	_, err := exec.LookPath("session-manager-plugin")
+	return err == nil
 }
 
 // Instance represents an EC2 instance in list views.

--- a/internal/aws/ec2_test.go
+++ b/internal/aws/ec2_test.go
@@ -1,0 +1,30 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSSMSessionCmd(t *testing.T) {
+	c := &Client{Region: "us-west-2", Profile: "staging"}
+	cmd := c.SSMSessionCmd("i-abc123", "my-server (i-abc123)")
+
+	assert.Equal(t, "sh", cmd.Path[len(cmd.Path)-2:])
+	// The shell command should contain the banner and aws ssm command
+	shellArg := cmd.Args[2] // sh -c "<shell command>"
+	assert.Contains(t, shellArg, "SSM Session: my-server (i-abc123)")
+	assert.Contains(t, shellArg, "aws ssm start-session --target i-abc123")
+	assert.Contains(t, shellArg, "--region us-west-2")
+	assert.Contains(t, shellArg, "--profile staging")
+}
+
+func TestSSMSessionCmdMinimal(t *testing.T) {
+	c := &Client{}
+	cmd := c.SSMSessionCmd("i-xyz789", "i-xyz789")
+
+	shellArg := cmd.Args[2]
+	assert.Contains(t, shellArg, "--target i-xyz789")
+	assert.NotContains(t, shellArg, "--region")
+	assert.NotContains(t, shellArg, "--profile")
+}

--- a/internal/views/ec2_list.go
+++ b/internal/views/ec2_list.go
@@ -23,9 +23,16 @@ type ec2InstanceDetailMsg struct {
 	err    error
 }
 
+type ec2SSMSessionFinishedMsg struct {
+	instanceID   string
+	instanceName string
+	err          error
+}
+
 // EC2List displays all EC2 instances.
 type EC2List struct {
 	ec2       aws.EC2Service
+	awsClient *aws.Client
 	table     ui.Table
 	instances []aws.Instance
 	filter    ui.Filter
@@ -41,6 +48,7 @@ func (e *EC2List) Title() string { return "EC2 Instances" }
 func (e *EC2List) KeyMap() []ui.KeyHint {
 	return []ui.KeyHint{
 		{Key: "enter/d", Desc: "details"},
+		{Key: "o", Desc: "connect (SSM)"},
 		{Key: "y", Desc: "copy ID"},
 		{Key: "s/S", Desc: "sort"},
 		{Key: "/", Desc: "filter"},
@@ -49,7 +57,7 @@ func (e *EC2List) KeyMap() []ui.KeyHint {
 }
 
 // NewEC2List creates the EC2 instance list view.
-func NewEC2List(ec2 aws.EC2Service) *EC2List {
+func NewEC2List(ec2 aws.EC2Service, awsClient *aws.Client) *EC2List {
 	columns := []table.Column{
 		{Title: "Instance ID", Width: 21},
 		{Title: "Name", Width: 24},
@@ -63,11 +71,12 @@ func NewEC2List(ec2 aws.EC2Service) *EC2List {
 
 	t := ui.NewTable(columns, nil)
 	return &EC2List{
-		ec2:     ec2,
-		table:   t,
-		filter:  ui.NewFilter(),
-		spinner: ui.NewSpinner("Loading EC2 instances..."),
-		loading: true,
+		ec2:       ec2,
+		awsClient: awsClient,
+		table:     t,
+		filter:    ui.NewFilter(),
+		spinner:   ui.NewSpinner("Loading EC2 instances..."),
+		loading:   true,
 	}
 }
 
@@ -113,6 +122,23 @@ func (e *EC2List) Update(m tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 		return e, nil
+
+	case ec2SSMSessionFinishedMsg:
+		if m.err != nil {
+			return e, func() tea.Msg {
+				return msg.ToastError("SSM session failed: " + m.err.Error())
+			}
+		}
+		label := m.instanceID
+		if m.instanceName != "" {
+			label = m.instanceName
+		}
+		// Refresh instance list — state may have changed during the session
+		e.loading = true
+		e.spinner.Show("Refreshing instances...")
+		return e, tea.Batch(e.spinner.Tick(), e.fetchInstances(), func() tea.Msg {
+			return msg.ToastSuccess("Session ended: " + label)
+		})
 
 	case ec2InstancesLoadedMsg:
 		e.loading = false
@@ -204,6 +230,41 @@ func (e *EC2List) Update(m tea.Msg) (tea.Model, tea.Cmd) {
 					return msg.ToastSuccess("Copied: " + id)
 				}
 			}
+		case "o":
+			selected := e.table.SelectedRow()
+			if selected == nil {
+				return e, nil
+			}
+			instanceID := selected[0]
+			var instanceName string
+			for _, inst := range e.instances {
+				if inst.ID == instanceID {
+					instanceName = inst.Name
+					if inst.State != "running" {
+						state := inst.State
+						return e, func() tea.Msg {
+							return msg.ToastError("Instance is " + state + " — must be running for SSM")
+						}
+					}
+					break
+				}
+			}
+			if !aws.SSMPluginAvailable() {
+				return e, func() tea.Msg {
+					return msg.ToastError("session-manager-plugin not found — install it first")
+				}
+			}
+			label := instanceID
+			if instanceName != "" {
+				label = instanceName + " (" + instanceID + ")"
+			}
+			eventlog.Infof(eventlog.CatAWS, "Starting SSM session: %s", label)
+			id := instanceID
+			name := instanceName
+			ssmCmd := e.awsClient.SSMSessionCmd(id, label)
+			return e, tea.ExecProcess(ssmCmd, func(err error) tea.Msg {
+				return ec2SSMSessionFinishedMsg{instanceID: id, instanceName: name, err: err}
+			})
 		}
 	}
 

--- a/services/aws/ec2.md
+++ b/services/aws/ec2.md
@@ -36,6 +36,7 @@ Pressing `enter` or `d` fetches full instance metadata via `DescribeInstances` a
 | Key | Action |
 |-----|--------|
 | `enter` / `d` | View instance details as JSON |
+| `o` | Start SSM session (connect to instance) |
 | `y` | Copy instance ID to clipboard |
 | `/` | Filter instances |
 | `r` | Refresh |
@@ -47,6 +48,17 @@ Instance states are color-coded:
 - **Green**: running, available, active
 - **Red**: stopped, terminated, deleted
 - **Yellow**: pending, starting, stopping
+
+## SSM Session
+
+Press `o` on a running instance to start an SSM Session Manager shell. This suspends the TUI, opens an interactive terminal session, and restores the TUI when you exit.
+
+**Prerequisites:**
+- AWS CLI installed (`aws` command available)
+- [Session Manager plugin](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html) installed
+- Instance must be running with SSM agent and an appropriate IAM instance profile
+
+If the instance is not running or the plugin is not installed, a toast error is shown.
 
 ## Service Layer
 


### PR DESCRIPTION
## Summary

Adds the ability to start an SSM Session Manager shell into an EC2 instance directly from the TUI. Press `o` on a running instance to connect.

## How it works

1. User presses `o` on a selected instance
2. Pre-flight checks: instance must be running, `session-manager-plugin` must be installed
3. TUI suspends via `tea.ExecProcess`, a colored banner is printed (`── SSM Session: my-server (i-abc123) ──`), and the `aws ssm start-session` command runs interactively
4. When the session ends, the TUI resumes, a toast is shown, and the instance list auto-refreshes (state may have changed during the session)

No new SDK dependencies — shells out to the AWS CLI which handles auth, websocket, and the session-manager-plugin protocol.

## Changes

| File | Change |
|------|--------|
| `internal/aws/ec2.go` | `SSMSessionCmd()` builds shell command with banner + profile/region flags; `SSMPluginAvailable()` checks for plugin via `exec.LookPath` |
| `internal/aws/ec2_test.go` | 2 tests for `SSMSessionCmd` (full flags and minimal) |
| `internal/views/ec2_list.go` | `o` keybinding with state/plugin validation, `ec2SSMSessionFinishedMsg` handler with auto-refresh |
| `internal/app/app.go` | Pass `awsClient` to `NewEC2List` for SSM command building |
| `services/aws/ec2.md` | Document `o` keybinding and SSM Session section with prerequisites |
| `README.md` | Add "SSM session connect" to EC2 description in services table |

## Prerequisites for users

- AWS CLI installed (`aws` command)
- [Session Manager plugin](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html) installed
- Instance must be running with SSM agent and appropriate IAM instance profile

Closes #10