### PR TITLE
Add EC2 instance mutation operations via action picker

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -175,6 +175,18 @@ func (m Model) Update(teaMsg tea.Msg) (tea.Model, tea.Cmd) {
 		m.confirm.Show(msg.Message, msg.Action)
 		return m, nil
 
+	case appmsg.RequestActionPickerMsg:
+		var options []ui.PickerOption
+		for _, opt := range msg.Options {
+			options = append(options, ui.PickerOption{Label: opt, Value: opt})
+		}
+		title := msg.Title
+		if title == "" {
+			title = "Action"
+		}
+		m.picker.Show("action", title, options, 0)
+		return m, nil
+
 	case appmsg.RequestSortPickerMsg:
 		var options []ui.PickerOption
 		for _, col := range msg.Columns {
@@ -193,8 +205,8 @@ func (m Model) Update(teaMsg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, cmd
 
 	case ui.PickerResultMsg:
-		// Sort picker: always route to current view (including clear/cancel)
-		if msg.ID == "sort" {
+		// Sort and action pickers: route to current view
+		if msg.ID == "sort" || msg.ID == "action" {
 			if msg.Selected == -1 {
 				return m, nil // esc cancel — do nothing
 			}

--- a/internal/aws/awstest/mock_ec2.go
+++ b/internal/aws/awstest/mock_ec2.go
@@ -1,0 +1,47 @@
+package awstest
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/mock"
+
+	"github.com/juthrbog/lazycloud/internal/aws"
+)
+
+// MockEC2Service is a testify mock implementing aws.EC2Service.
+type MockEC2Service struct {
+	mock.Mock
+}
+
+var _ aws.EC2Service = (*MockEC2Service)(nil)
+
+func (m *MockEC2Service) ListInstances(ctx context.Context) ([]aws.Instance, error) {
+	args := m.Called(ctx)
+	return args.Get(0).([]aws.Instance), args.Error(1)
+}
+
+func (m *MockEC2Service) GetInstanceDetail(ctx context.Context, instanceID string) (*aws.InstanceDetail, error) {
+	args := m.Called(ctx, instanceID)
+	val, _ := args.Get(0).(*aws.InstanceDetail)
+	return val, args.Error(1)
+}
+
+func (m *MockEC2Service) StartInstance(ctx context.Context, instanceID string) error {
+	args := m.Called(ctx, instanceID)
+	return args.Error(0)
+}
+
+func (m *MockEC2Service) StopInstance(ctx context.Context, instanceID string) error {
+	args := m.Called(ctx, instanceID)
+	return args.Error(0)
+}
+
+func (m *MockEC2Service) RebootInstance(ctx context.Context, instanceID string) error {
+	args := m.Called(ctx, instanceID)
+	return args.Error(0)
+}
+
+func (m *MockEC2Service) TerminateInstance(ctx context.Context, instanceID string) error {
+	args := m.Called(ctx, instanceID)
+	return args.Error(0)
+}

--- a/internal/aws/ec2.go
+++ b/internal/aws/ec2.go
@@ -17,6 +17,10 @@ import (
 type EC2Service interface {
 	ListInstances(ctx context.Context) ([]Instance, error)
 	GetInstanceDetail(ctx context.Context, instanceID string) (*InstanceDetail, error)
+	StartInstance(ctx context.Context, instanceID string) error
+	StopInstance(ctx context.Context, instanceID string) error
+	RebootInstance(ctx context.Context, instanceID string) error
+	TerminateInstance(ctx context.Context, instanceID string) error
 }
 
 // EC2ServiceImpl is the real AWS-backed implementation of EC2Service.
@@ -170,6 +174,42 @@ func (svc *EC2ServiceImpl) GetInstanceDetail(ctx context.Context, instanceID str
 	}
 
 	return nil, nil
+}
+
+// StartInstance starts a stopped EC2 instance.
+func (svc *EC2ServiceImpl) StartInstance(ctx context.Context, instanceID string) error {
+	ec2c := svc.client.EC2Client()
+	_, err := ec2c.StartInstances(ctx, &ec2.StartInstancesInput{
+		InstanceIds: []string{instanceID},
+	})
+	return err
+}
+
+// StopInstance stops a running EC2 instance.
+func (svc *EC2ServiceImpl) StopInstance(ctx context.Context, instanceID string) error {
+	ec2c := svc.client.EC2Client()
+	_, err := ec2c.StopInstances(ctx, &ec2.StopInstancesInput{
+		InstanceIds: []string{instanceID},
+	})
+	return err
+}
+
+// RebootInstance reboots a running EC2 instance.
+func (svc *EC2ServiceImpl) RebootInstance(ctx context.Context, instanceID string) error {
+	ec2c := svc.client.EC2Client()
+	_, err := ec2c.RebootInstances(ctx, &ec2.RebootInstancesInput{
+		InstanceIds: []string{instanceID},
+	})
+	return err
+}
+
+// TerminateInstance terminates an EC2 instance. This is irreversible.
+func (svc *EC2ServiceImpl) TerminateInstance(ctx context.Context, instanceID string) error {
+	ec2c := svc.client.EC2Client()
+	_, err := ec2c.TerminateInstances(ctx, &ec2.TerminateInstancesInput{
+		InstanceIds: []string{instanceID},
+	})
+	return err
 }
 
 // mapInstance extracts list-view fields from an SDK instance.

--- a/internal/msg/messages.go
+++ b/internal/msg/messages.go
@@ -62,6 +62,13 @@ type RequestConfirmMsg struct {
 	Action  string
 }
 
+// RequestActionPickerMsg asks the app to show an action picker.
+// The PickerResultMsg (ID="action") is routed back to the current view.
+type RequestActionPickerMsg struct {
+	Title   string   // picker title
+	Options []string // action labels
+}
+
 // RequestSortPickerMsg asks the app to show a column sort picker.
 // The PickerResultMsg (ID="sort") is routed back to the current view.
 type RequestSortPickerMsg struct {

--- a/internal/views/ec2_list.go
+++ b/internal/views/ec2_list.go
@@ -3,6 +3,7 @@ package views
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"charm.land/bubbles/v2/table"
 	tea "charm.land/bubbletea/v2"
@@ -29,31 +30,45 @@ type ec2SSMSessionFinishedMsg struct {
 	err          error
 }
 
+type ec2InstanceMutatedMsg struct {
+	action     string // "started", "stopped", "rebooted", "terminated"
+	instanceID string
+	err        error
+}
+
 // EC2List displays all EC2 instances.
 type EC2List struct {
-	ec2       aws.EC2Service
-	awsClient *aws.Client
-	table     ui.Table
-	instances []aws.Instance
-	filter    ui.Filter
-	spinner   ui.Spinner
-	loading   bool
-	err       error
-	width     int
-	height    int
+	ec2               aws.EC2Service
+	awsClient         *aws.Client
+	table             ui.Table
+	instances         []aws.Instance
+	filter            ui.Filter
+	spinner           ui.Spinner
+	loading           bool
+	pendingInstanceID string // instance targeted by a pending action
+	pendingAction     string // action name awaiting confirmation
+	err               error
+	width             int
+	height            int
 }
 
 func (e *EC2List) ID() string    { return "ec2_list" }
 func (e *EC2List) Title() string { return "EC2 Instances" }
 func (e *EC2List) KeyMap() []ui.KeyHint {
-	return []ui.KeyHint{
+	hints := []ui.KeyHint{
 		{Key: "enter/d", Desc: "details"},
 		{Key: "o", Desc: "connect (SSM)"},
-		{Key: "y", Desc: "copy ID"},
-		{Key: "s/S", Desc: "sort"},
-		{Key: "/", Desc: "filter"},
-		{Key: "r", Desc: "refresh"},
 	}
+	if !ui.ReadOnly {
+		hints = append(hints, ui.KeyHint{Key: "m", Desc: "manage"})
+	}
+	hints = append(hints,
+		ui.KeyHint{Key: "y", Desc: "copy ID"},
+		ui.KeyHint{Key: "s/S", Desc: "sort"},
+		ui.KeyHint{Key: "/", Desc: "filter"},
+		ui.KeyHint{Key: "r", Desc: "refresh"},
+	)
+	return hints
 }
 
 // NewEC2List creates the EC2 instance list view.
@@ -120,8 +135,56 @@ func (e *EC2List) Update(m tea.Msg) (tea.Model, tea.Cmd) {
 			} else if m.Selected >= 0 {
 				e.table.Sort(m.Selected)
 			}
+		} else if m.ID == "action" && m.Selected >= 0 {
+			id := e.pendingInstanceID
+			switch m.Value {
+			case "Start":
+				return e, e.startInstance(id)
+			case "Stop", "Reboot", "Terminate":
+				e.pendingAction = m.Value
+				action := m.Value
+				return e, func() tea.Msg {
+					return msg.RequestConfirmMsg{
+						Message: action + " instance " + id + "?",
+						Action:  "ec2_" + strings.ToLower(action),
+					}
+				}
+			}
 		}
 		return e, nil
+
+	case ui.ConfirmResultMsg:
+		if !m.Confirmed {
+			e.pendingInstanceID = ""
+			e.pendingAction = ""
+			return e, nil
+		}
+		id := e.pendingInstanceID
+		e.pendingInstanceID = ""
+		switch m.Action {
+		case "ec2_stop":
+			return e, e.stopInstance(id)
+		case "ec2_reboot":
+			return e, e.rebootInstance(id)
+		case "ec2_terminate":
+			return e, e.terminateInstance(id)
+		}
+		return e, nil
+
+	case ec2InstanceMutatedMsg:
+		if m.err != nil {
+			e.err = m.err
+			return e, func() tea.Msg {
+				return msg.ToastError(m.action + " failed: " + m.err.Error())
+			}
+		}
+		e.loading = true
+		e.spinner.Show("Refreshing instances...")
+		action := m.action
+		id := m.instanceID
+		return e, tea.Batch(e.spinner.Tick(), e.fetchInstances(), func() tea.Msg {
+			return msg.ToastSuccess("Instance " + action + ": " + id)
+		})
 
 	case ec2SSMSessionFinishedMsg:
 		if m.err != nil {
@@ -230,23 +293,47 @@ func (e *EC2List) Update(m tea.Msg) (tea.Model, tea.Cmd) {
 					return msg.ToastSuccess("Copied: " + id)
 				}
 			}
+		case "m":
+			if ui.ReadOnly {
+				return e, func() tea.Msg {
+					return msg.ToastError("ReadOnly mode — press W to switch")
+				}
+			}
+			selected := e.table.SelectedRow()
+			if selected == nil {
+				return e, nil
+			}
+			inst := e.findInstance(selected[0])
+			if inst == nil {
+				return e, nil
+			}
+			actions := e.actionsForState(inst.State)
+			if len(actions) == 0 {
+				state := inst.State
+				return e, func() tea.Msg {
+					return msg.ToastError("No actions available for " + state + " instance")
+				}
+			}
+			e.pendingInstanceID = inst.ID
+			return e, func() tea.Msg {
+				return msg.RequestActionPickerMsg{
+					Title:   "Manage Instance",
+					Options: actions,
+				}
+			}
 		case "o":
 			selected := e.table.SelectedRow()
 			if selected == nil {
 				return e, nil
 			}
-			instanceID := selected[0]
-			var instanceName string
-			for _, inst := range e.instances {
-				if inst.ID == instanceID {
-					instanceName = inst.Name
-					if inst.State != "running" {
-						state := inst.State
-						return e, func() tea.Msg {
-							return msg.ToastError("Instance is " + state + " — must be running for SSM")
-						}
-					}
-					break
+			inst := e.findInstance(selected[0])
+			if inst == nil {
+				return e, nil
+			}
+			if inst.State != "running" {
+				state := inst.State
+				return e, func() tea.Msg {
+					return msg.ToastError("Instance is " + state + " — must be running for SSM")
 				}
 			}
 			if !aws.SSMPluginAvailable() {
@@ -254,13 +341,13 @@ func (e *EC2List) Update(m tea.Msg) (tea.Model, tea.Cmd) {
 					return msg.ToastError("session-manager-plugin not found — install it first")
 				}
 			}
-			label := instanceID
-			if instanceName != "" {
-				label = instanceName + " (" + instanceID + ")"
+			label := inst.ID
+			if inst.Name != "" {
+				label = inst.Name + " (" + inst.ID + ")"
 			}
 			eventlog.Infof(eventlog.CatAWS, "Starting SSM session: %s", label)
-			id := instanceID
-			name := instanceName
+			id := inst.ID
+			name := inst.Name
 			ssmCmd := e.awsClient.SSMSessionCmd(id, label)
 			return e, tea.ExecProcess(ssmCmd, func(err error) tea.Msg {
 				return ec2SSMSessionFinishedMsg{instanceID: id, instanceName: name, err: err}
@@ -277,6 +364,62 @@ func (e *EC2List) Update(m tea.Msg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 	e.table, cmd = e.table.Update(m)
 	return e, cmd
+}
+
+func (e *EC2List) findInstance(id string) *aws.Instance {
+	for i := range e.instances {
+		if e.instances[i].ID == id {
+			return &e.instances[i]
+		}
+	}
+	return nil
+}
+
+func (e *EC2List) actionsForState(state string) []string {
+	switch state {
+	case "stopped":
+		return []string{"Start"}
+	case "running":
+		return []string{"Stop", "Reboot", "Terminate"}
+	default:
+		return nil
+	}
+}
+
+func (e *EC2List) startInstance(id string) tea.Cmd {
+	svc := e.ec2
+	return func() tea.Msg {
+		eventlog.Infof(eventlog.CatAWS, "Starting instance: %s", id)
+		err := svc.StartInstance(context.Background(), id)
+		return ec2InstanceMutatedMsg{action: "started", instanceID: id, err: err}
+	}
+}
+
+func (e *EC2List) stopInstance(id string) tea.Cmd {
+	svc := e.ec2
+	return func() tea.Msg {
+		eventlog.Infof(eventlog.CatAWS, "Stopping instance: %s", id)
+		err := svc.StopInstance(context.Background(), id)
+		return ec2InstanceMutatedMsg{action: "stopped", instanceID: id, err: err}
+	}
+}
+
+func (e *EC2List) rebootInstance(id string) tea.Cmd {
+	svc := e.ec2
+	return func() tea.Msg {
+		eventlog.Infof(eventlog.CatAWS, "Rebooting instance: %s", id)
+		err := svc.RebootInstance(context.Background(), id)
+		return ec2InstanceMutatedMsg{action: "rebooted", instanceID: id, err: err}
+	}
+}
+
+func (e *EC2List) terminateInstance(id string) tea.Cmd {
+	svc := e.ec2
+	return func() tea.Msg {
+		eventlog.Infof(eventlog.CatAWS, "Terminating instance: %s", id)
+		err := svc.TerminateInstance(context.Background(), id)
+		return ec2InstanceMutatedMsg{action: "terminated", instanceID: id, err: err}
+	}
 }
 
 func (e *EC2List) buildRows(instances []aws.Instance) ([]table.Row, []table.Row) {

--- a/internal/views/ec2_list_test.go
+++ b/internal/views/ec2_list_test.go
@@ -1,0 +1,194 @@
+package views
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/juthrbog/lazycloud/internal/aws"
+	"github.com/juthrbog/lazycloud/internal/aws/awstest"
+	"github.com/juthrbog/lazycloud/internal/msg"
+	"github.com/juthrbog/lazycloud/internal/ui"
+)
+
+func newTestEC2List() (*EC2List, *awstest.MockEC2Service) {
+	m := new(awstest.MockEC2Service)
+	view := NewEC2List(m, nil) // nil awsClient — SSM not tested here
+	view.Update(tea.WindowSizeMsg{Width: 120, Height: 24})
+	return view, m
+}
+
+func loadInstances(view *EC2List, instances []aws.Instance) {
+	view.Update(ec2InstancesLoadedMsg{instances: instances})
+}
+
+var testRunningInstance = aws.Instance{ID: "i-running", Name: "web-1", State: "running"}
+var testStoppedInstance = aws.Instance{ID: "i-stopped", Name: "batch-1", State: "stopped"}
+var testTerminatedInstance = aws.Instance{ID: "i-terminated", Name: "old-1", State: "terminated"}
+
+// --- ReadOnly guard ---
+
+func TestEC2List_ReadOnlyBlocksManage(t *testing.T) {
+	ui.ReadOnly = true
+	defer func() { ui.ReadOnly = true }()
+
+	view, _ := newTestEC2List()
+	loadInstances(view, []aws.Instance{testRunningInstance})
+
+	_, cmd := view.Update(keyPress('m'))
+	require.NotNil(t, cmd)
+
+	result := cmd()
+	toast, ok := result.(msg.ToastMsg)
+	require.True(t, ok, "expected ToastMsg, got %T", result)
+	assert.Equal(t, 2, toast.Level) // error
+	assert.Contains(t, toast.Text, "ReadOnly")
+}
+
+// --- Action picker ---
+
+func TestEC2List_ManageRunningInstance(t *testing.T) {
+	ui.ReadOnly = false
+	defer func() { ui.ReadOnly = true }()
+
+	view, _ := newTestEC2List()
+	loadInstances(view, []aws.Instance{testRunningInstance})
+
+	_, cmd := view.Update(keyPress('m'))
+	require.NotNil(t, cmd)
+
+	result := cmd()
+	picker, ok := result.(msg.RequestActionPickerMsg)
+	require.True(t, ok, "expected RequestActionPickerMsg, got %T", result)
+	assert.Equal(t, []string{"Stop", "Reboot", "Terminate"}, picker.Options)
+	assert.Equal(t, "i-running", view.pendingInstanceID)
+}
+
+func TestEC2List_ManageStoppedInstance(t *testing.T) {
+	ui.ReadOnly = false
+	defer func() { ui.ReadOnly = true }()
+
+	view, _ := newTestEC2List()
+	loadInstances(view, []aws.Instance{testStoppedInstance})
+
+	_, cmd := view.Update(keyPress('m'))
+	require.NotNil(t, cmd)
+
+	result := cmd()
+	picker, ok := result.(msg.RequestActionPickerMsg)
+	require.True(t, ok, "expected RequestActionPickerMsg, got %T", result)
+	assert.Equal(t, []string{"Start"}, picker.Options)
+}
+
+func TestEC2List_ManageTerminatedInstance(t *testing.T) {
+	ui.ReadOnly = false
+	defer func() { ui.ReadOnly = true }()
+
+	view, _ := newTestEC2List()
+	loadInstances(view, []aws.Instance{testTerminatedInstance})
+
+	_, cmd := view.Update(keyPress('m'))
+	require.NotNil(t, cmd)
+
+	result := cmd()
+	toast, ok := result.(msg.ToastMsg)
+	require.True(t, ok, "expected ToastMsg, got %T", result)
+	assert.Contains(t, toast.Text, "No actions available")
+}
+
+// --- Picker result handling ---
+
+func TestEC2List_StopTriggersConfirm(t *testing.T) {
+	view, _ := newTestEC2List()
+	loadInstances(view, []aws.Instance{testRunningInstance})
+	view.pendingInstanceID = "i-running"
+
+	_, cmd := view.Update(ui.PickerResultMsg{ID: "action", Selected: 0, Value: "Stop"})
+	require.NotNil(t, cmd)
+
+	result := cmd()
+	confirm, ok := result.(msg.RequestConfirmMsg)
+	require.True(t, ok, "expected RequestConfirmMsg, got %T", result)
+	assert.Equal(t, "ec2_stop", confirm.Action)
+	assert.Contains(t, confirm.Message, "i-running")
+}
+
+func TestEC2List_TerminateTriggersConfirm(t *testing.T) {
+	view, _ := newTestEC2List()
+	loadInstances(view, []aws.Instance{testRunningInstance})
+	view.pendingInstanceID = "i-running"
+
+	_, cmd := view.Update(ui.PickerResultMsg{ID: "action", Selected: 2, Value: "Terminate"})
+	require.NotNil(t, cmd)
+
+	result := cmd()
+	confirm, ok := result.(msg.RequestConfirmMsg)
+	require.True(t, ok, "expected RequestConfirmMsg, got %T", result)
+	assert.Equal(t, "ec2_terminate", confirm.Action)
+}
+
+func TestEC2List_StartExecutesImmediately(t *testing.T) {
+	view, mockSvc := newTestEC2List()
+	loadInstances(view, []aws.Instance{testStoppedInstance})
+	view.pendingInstanceID = "i-stopped"
+
+	mockSvc.On("StartInstance", mock.Anything, "i-stopped").Return(nil)
+
+	_, cmd := view.Update(ui.PickerResultMsg{ID: "action", Selected: 0, Value: "Start"})
+	require.NotNil(t, cmd)
+
+	// Execute the command — it should call StartInstance
+	result := cmd()
+	mutated, ok := result.(ec2InstanceMutatedMsg)
+	require.True(t, ok, "expected ec2InstanceMutatedMsg, got %T", result)
+	assert.Equal(t, "started", mutated.action)
+	assert.Equal(t, "i-stopped", mutated.instanceID)
+	assert.NoError(t, mutated.err)
+	mockSvc.AssertCalled(t, "StartInstance", mock.Anything, "i-stopped")
+}
+
+// --- KeyMap ---
+
+func TestEC2List_KeyMapHidesManageInReadOnly(t *testing.T) {
+	ui.ReadOnly = true
+	defer func() { ui.ReadOnly = true }()
+
+	view, _ := newTestEC2List()
+	hints := view.KeyMap()
+
+	descs := make([]string, len(hints))
+	for i, h := range hints {
+		descs[i] = h.Desc
+	}
+	assert.NotContains(t, descs, "manage")
+	assert.Contains(t, descs, "details")
+}
+
+func TestEC2List_KeyMapShowsManageInReadWrite(t *testing.T) {
+	ui.ReadOnly = false
+	defer func() { ui.ReadOnly = true }()
+
+	view, _ := newTestEC2List()
+	hints := view.KeyMap()
+
+	descs := make([]string, len(hints))
+	for i, h := range hints {
+		descs[i] = h.Desc
+	}
+	assert.Contains(t, descs, "manage")
+}
+
+// --- actionsForState ---
+
+func TestEC2List_ActionsForState(t *testing.T) {
+	view, _ := newTestEC2List()
+
+	assert.Equal(t, []string{"Start"}, view.actionsForState("stopped"))
+	assert.Equal(t, []string{"Stop", "Reboot", "Terminate"}, view.actionsForState("running"))
+	assert.Nil(t, view.actionsForState("pending"))
+	assert.Nil(t, view.actionsForState("stopping"))
+	assert.Nil(t, view.actionsForState("terminated"))
+}

--- a/services/aws/ec2.md
+++ b/services/aws/ec2.md
@@ -37,6 +37,7 @@ Pressing `enter` or `d` fetches full instance metadata via `DescribeInstances` a
 |-----|--------|
 | `enter` / `d` | View instance details as JSON |
 | `o` | Start SSM session (connect to instance) |
+| `m` | Manage instance (start/stop/reboot/terminate picker) |
 | `y` | Copy instance ID to clipboard |
 | `/` | Filter instances |
 | `r` | Refresh |
@@ -48,6 +49,22 @@ Instance states are color-coded:
 - **Green**: running, available, active
 - **Red**: stopped, terminated, deleted
 - **Yellow**: pending, starting, stopping
+
+## Instance Operations
+
+Press `m` on an instance to open an action picker showing only the valid operations for the instance's current state:
+
+| Instance state | Available actions |
+|---------------|-------------------|
+| running | Stop, Reboot, Terminate |
+| stopped | Start |
+| pending, stopping, etc. | No actions available |
+
+- **Start** executes immediately (safe, reversible)
+- **Stop**, **Reboot**, and **Terminate** require typing "confirm" before proceeding
+- All operations are gated behind ReadWrite mode — press `W` to switch from ReadOnly
+
+After any operation, the instance list auto-refreshes to show the updated state.
 
 ## SSM Session
 
@@ -68,7 +85,11 @@ If the instance is not running or the plugin is not installed, a toast error is 
 type EC2Service interface {
     ListInstances(ctx context.Context) ([]Instance, error)
     GetInstanceDetail(ctx context.Context, instanceID string) (*InstanceDetail, error)
+    StartInstance(ctx context.Context, instanceID string) error
+    StopInstance(ctx context.Context, instanceID string) error
+    RebootInstance(ctx context.Context, instanceID string) error
+    TerminateInstance(ctx context.Context, instanceID string) error
 }
 ```
 
-Pagination is handled automatically in `ListInstances`. The service uses `DescribeInstances` for both operations.
+Pagination is handled automatically in `ListInstances`. Each mutation method wraps the corresponding EC2 SDK call (`StartInstances`, `StopInstances`, `RebootInstances`, `TerminateInstances`). A shared `MockEC2Service` in `internal/aws/awstest/` enables testing views without AWS credentials.


### PR DESCRIPTION
## Summary

Adds start, stop, reboot, and terminate operations for EC2 instances behind a context-aware action picker. Press `m` on an instance to see only the valid actions for its current state.

## How it works

1. Press `m` on an instance (requires ReadWrite mode)
2. A picker shows valid actions based on instance state:
   - **running** → Stop, Reboot, Terminate
   - **stopped** → Start
   - **pending/stopping/etc.** → toast: "No actions available"
3. **Start** executes immediately (safe, reversible)
4. **Stop/Reboot/Terminate** show a type-to-confirm dialog
5. Instance list auto-refreshes after any mutation

## Changes

### Service layer (`internal/aws/ec2.go`)
- Added `StartInstance`, `StopInstance`, `RebootInstance`, `TerminateInstance` to `EC2Service` interface
- Each wraps the corresponding EC2 SDK call (`StartInstances`, `StopInstances`, `RebootInstances`, `TerminateInstances`)

### Action picker (`internal/msg/messages.go`, `internal/app/app.go`)
- New `RequestActionPickerMsg` type — generic, reusable by future services
- App handles it like `RequestSortPickerMsg`: shows picker with ID `"action"`, routes result to current view

### View (`internal/views/ec2_list.go`)
- `m` keybinding with ReadOnly guard
- `actionsForState()` maps instance state to valid actions
- `findInstance()` helper (also simplifies the SSM `o` handler)
- `PickerResultMsg{ID:"action"}` handler: Start → immediate, others → `RequestConfirmMsg`
- `ConfirmResultMsg` handler dispatches to mutation commands
- `ec2InstanceMutatedMsg` handler: refresh list + toast on success/error
- `KeyMap()` conditionally shows `m` hint only in ReadWrite mode

### Mock (`internal/aws/awstest/mock_ec2.go`)
- New `MockEC2Service` with all 6 interface methods, following `MockS3Service` pattern

### Tests (`internal/views/ec2_list_test.go`) — 10 tests

| Test | Validates |
|------|-----------|
| `TestEC2List_ReadOnlyBlocksManage` | `m` in ReadOnly → toast error |
| `TestEC2List_ManageRunningInstance` | Picker shows Stop/Reboot/Terminate |
| `TestEC2List_ManageStoppedInstance` | Picker shows Start |
| `TestEC2List_ManageTerminatedInstance` | Toast: no actions available |
| `TestEC2List_StopTriggersConfirm` | Stop → RequestConfirmMsg |
| `TestEC2List_TerminateTriggersConfirm` | Terminate → RequestConfirmMsg |
| `TestEC2List_StartExecutesImmediately` | Start → calls StartInstance directly |
| `TestEC2List_KeyMapHidesManageInReadOnly` | `m` not in KeyMap hints |
| `TestEC2List_KeyMapShowsManageInReadWrite` | `m` in KeyMap hints |
| `TestEC2List_ActionsForState` | State → actions mapping |

### Documentation (`services/aws/ec2.md`)
- Added `m` to keybindings table
- New "Instance Operations" section with state/action matrix
- Updated Service Layer section with all 6 interface methods

Closes #9