### PR TITLE
Set up GitHub Releases with GoReleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ go.work.sum
 # Binary
 lazycloud
 
+# GoReleaser
+dist/
+
 # LocalStack
 localstack-data/
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,39 @@
+version: 2
+
+builds:
+  - main: .
+    binary: lazycloud
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X github.com/juthrbog/lazycloud/internal/version.Version={{.Version}}
+      - -X github.com/juthrbog/lazycloud/internal/version.Commit={{.ShortCommit}}
+      - -X github.com/juthrbog/lazycloud/internal/version.Date={{.Date}}
+
+archives:
+  - formats:
+      - tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^ci:"
+
+release:
+  github:
+    owner: juthrbog
+    name: lazycloud

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ A terminal user interface (TUI) for browsing, managing, and interacting with AWS
 
 ## Getting Started
 
+### Install from releases
+
+Download the latest binary from the [Releases](https://github.com/juthrbog/lazycloud/releases) page, extract it, and add it to your `PATH`.
+
+### Build from source
+
 ```bash
 # Build
 go build -o lazycloud .
@@ -64,6 +70,7 @@ task dev               # run against LocalStack
 | `--log`           | Path to debug log file                                              |
 | `--read-write`    | Start in ReadWrite mode (default: ReadOnly)                         |
 | `--init-config`   | Write default config file and exit                                  |
+| `--version`       | Print version and exit                                              |
 
 ### Keybindings
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -128,6 +128,7 @@ tasks:
     cmds:
       - rm -f {{.BINARY}}
       - rm -rf .task/
+      - rm -rf dist/
 
   deps:
     desc: Download and tidy dependencies
@@ -135,7 +136,15 @@ tasks:
       - go mod download
       - go mod tidy
 
+  # ─── Release ────────────────────────────────────────────
+
   snapshot:
-    desc: Build cross-platform binaries (requires goreleaser)
+    desc: Build cross-platform binaries locally (requires goreleaser)
     cmds:
       - goreleaser build --snapshot --clean
+
+  release:
+    desc: "Tag and push a new release (usage: task release -- v0.1.0)"
+    cmds:
+      - git tag {{.CLI_ARGS}}
+      - git push origin {{.CLI_ARGS}}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,8 @@
+package version
+
+// Set via ldflags at build time by GoReleaser.
+var (
+	Version = "dev"
+	Commit  = "none"
+	Date    = "unknown"
+)

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juthrbog/lazycloud/internal/app"
 	"github.com/juthrbog/lazycloud/internal/config"
 	"github.com/juthrbog/lazycloud/internal/ui"
+	"github.com/juthrbog/lazycloud/internal/version"
 )
 
 func main() {
@@ -24,7 +25,13 @@ func main() {
 	configPath := flag.String("config", "", "path to config file")
 	readWrite := flag.Bool("read-write", false, "start in ReadWrite mode (default: ReadOnly)")
 	initConfig := flag.Bool("init-config", false, "write default config file and exit")
+	showVersion := flag.Bool("version", false, "print version and exit")
 	flag.Parse()
+
+	if *showVersion {
+		fmt.Printf("lazycloud %s (commit %s, built %s)\n", version.Version, version.Commit, version.Date)
+		return
+	}
 
 	// Write default config and exit
 	if *initConfig {


### PR DESCRIPTION
## Summary

Adds release infrastructure so that tagging a version automatically builds cross-platform binaries and creates a GitHub Release with checksums and a changelog.

## How to release

```bash
# Via Taskfile
task release -- v0.1.0

# Or manually
git tag v0.1.0
git push origin v0.1.0
```

This triggers the release workflow which:
1. Checks out with full git history
2. Builds binaries for **linux** and **macOS** (amd64 + arm64)
3. Creates `.tar.gz` archives with checksums
4. Generates a changelog from commit messages since the last tag
5. Creates a GitHub Release with all artifacts

## Changes

| File | Purpose |
|------|---------|
| `internal/version/version.go` | Version/Commit/Date variables, defaults to "dev" — populated via ldflags at build time |
| `main.go` | Added `--version` flag that prints `lazycloud dev (commit none, built unknown)` in dev, or real values in releases |
| `.goreleaser.yml` | GoReleaser v2 config: linux/darwin builds, amd64/arm64, checksums, changelog, ldflags injection |
| `.github/workflows/release.yml` | GitHub Actions workflow triggered on `v*` tags, uses `goreleaser-action@v6` |
| `Taskfile.yml` | Added `release` task (tag + push shortcut), `dist/` in `clean` task |
| `.gitignore` | Added `dist/` (GoReleaser output directory) |
| `README.md` | Added `--version` to CLI flags table, "Install from releases" section in Getting Started |

## Build matrix

| OS | Arch |
|----|------|
| linux | amd64, arm64 |
| darwin (macOS) | amd64, arm64 |

No Windows — this is a TUI that depends on Unix terminal features.