### PR TITLE
Fix toast auto-dismiss for view-originated toasts

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -94,6 +94,9 @@ func (m Model) Init() tea.Cmd {
 }
 
 func (m Model) Update(teaMsg tea.Msg) (tea.Model, tea.Cmd) {
+	// Remove expired toasts as a fallback in case dismiss commands were dropped.
+	m.toasts.Cleanup()
+
 	// Picker intercepts all input when visible
 	if m.picker.Visible() {
 		var cmd tea.Cmd

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juthrbog/lazycloud/internal/config"
 	"github.com/juthrbog/lazycloud/internal/msg"
+	"github.com/juthrbog/lazycloud/internal/ui"
 )
 
 func newTestModel(width, height int) Model {
@@ -217,6 +218,54 @@ func TestApplyThemeReturnsToDismissToast(t *testing.T) {
 	m := newTestModel(140, 40)
 	_, cmd := m.applyTheme("dracula")
 	assert.NotNil(t, cmd)
+}
+
+// --- Toast dismiss ---
+
+func TestToastMsgHandlerReturnsDismissCmd(t *testing.T) {
+	m := newTestModel(140, 40)
+
+	result, cmd := m.Update(msg.ToastMsg{Text: "ReadOnly mode", Level: 2})
+	m = result.(Model)
+
+	assert.True(t, m.toasts.HasActive(), "toast should be visible after ToastMsg")
+	assert.NotNil(t, cmd, "dismiss cmd must be returned from ToastMsg handler")
+}
+
+func TestToastDismissMsgRemovesToast(t *testing.T) {
+	m := newTestModel(140, 40)
+
+	id, _ := m.toasts.Add("test toast", ui.ToastInfo, 0)
+	assert.True(t, m.toasts.HasActive())
+
+	result, _ := m.Update(ui.ToastDismissMsg{ID: id})
+	m = result.(Model)
+
+	assert.False(t, m.toasts.HasActive(), "toast should be dismissed")
+}
+
+func TestReadOnlyToastFullPath(t *testing.T) {
+	// Simulate the full path: view closure → ToastMsg → dismiss cmd
+	ui.ReadOnly = true
+	defer func() { ui.ReadOnly = true }()
+
+	m := newTestModel(140, 40)
+
+	result, _ := m.Update(msg.NavigateMsg{ViewID: "ec2_list"})
+	m = result.(Model)
+
+	// Press 'm' — view returns closure that produces ToastError
+	result, viewCmd := m.Update(tea.KeyPressMsg{Code: 'm', Text: "m"})
+	m = result.(Model)
+	assert.NotNil(t, viewCmd)
+
+	// Execute closure, feed result back to Update
+	toastMsg := viewCmd()
+	result, dismissCmd := m.Update(toastMsg)
+	m = result.(Model)
+
+	assert.True(t, m.toasts.HasActive(), "toast should be visible")
+	assert.NotNil(t, dismissCmd, "dismiss cmd must be returned")
 }
 
 // --- Key hints ---

--- a/internal/ui/toast.go
+++ b/internal/ui/toast.go
@@ -86,21 +86,44 @@ func (tm *ToastManager) Dismiss(id int) {
 	}
 }
 
-// HasActive returns whether any toasts are showing.
+// Cleanup removes toasts that have exceeded their duration.
+// This is a fallback for cases where the dismiss command may not fire
+// (e.g., when toasts originate from view closures routed through the
+// message loop). Call from Update periodically.
+func (tm *ToastManager) Cleanup() {
+	now := time.Now()
+	filtered := tm.toasts[:0]
+	for _, t := range tm.toasts {
+		if now.Sub(t.CreatedAt) < t.Duration {
+			filtered = append(filtered, t)
+		}
+	}
+	tm.toasts = filtered
+}
+
+// HasActive returns whether any non-expired toasts exist.
 func (tm ToastManager) HasActive() bool {
-	return len(tm.toasts) > 0
+	now := time.Now()
+	for _, t := range tm.toasts {
+		if now.Sub(t.CreatedAt) < t.Duration {
+			return true
+		}
+	}
+	return false
 }
 
 // View renders the toast stack as a bordered block.
+// Skips expired toasts that haven't been cleaned up yet.
 func (tm ToastManager) View(width int) string {
-	if len(tm.toasts) == 0 {
-		return ""
-	}
-
 	t := ActiveTheme
+	now := time.Now()
 	var lines []string
 
 	for _, toast := range tm.toasts {
+		if now.Sub(toast.CreatedAt) >= toast.Duration {
+			continue
+		}
+
 		var icon string
 		var style lipgloss.Style
 
@@ -118,6 +141,10 @@ func (tm ToastManager) View(width int) string {
 
 		line := style.Render(fmt.Sprintf(" %s %s ", icon, toast.Text))
 		lines = append(lines, line)
+	}
+
+	if len(lines) == 0 {
+		return ""
 	}
 
 	content := strings.Join(lines, "\n")


### PR DESCRIPTION
## Summary

Fixes toasts created by view closures (e.g., ReadOnly guard, SSM plugin check, no actions available) not auto-dismissing. These toasts would persist indefinitely, stacking with subsequent toasts.

## Investigation

Unit tests confirmed the app logic is correct — the dismiss cmd IS returned through the full `view closure → ToastMsg → app handler → dismiss cmd` path. The issue is in Bubble Tea's runtime cmd execution: the dismiss cmd returned from a nested message handler doesn't reliably fire in all scenarios.

Since we can't fix the Bubble Tea runtime, this PR adds a defensive time-based fallback.

## Fix

Three-layer defense in `internal/ui/toast.go`:

| Method | Change |
|--------|--------|
| `Cleanup()` (new) | Pointer receiver — removes expired toasts by comparing `CreatedAt + Duration` against `time.Now()` |
| `HasActive()` | Now checks toast age — expired toasts return false even if not yet cleaned up |
| `View()` | Skips expired toasts during rendering |

Called from `internal/app/app.go`:
- `m.toasts.Cleanup()` at the top of every `Update()` call, ensuring stale toasts are removed from state on the next message

The existing `Dismiss()` method and dismiss cmd remain unchanged — they still handle the normal fast path. The time-based check is purely a fallback.

## Tests (3 new)

| Test | Validates |
|------|-----------|
| `TestToastMsgHandlerReturnsDismissCmd` | ToastMsg handler adds toast and returns dismiss cmd |
| `TestToastDismissMsgRemovesToast` | ToastDismissMsg correctly removes a toast |
| `TestReadOnlyToastFullPath` | Full path: EC2 `m` key in ReadOnly → closure → ToastMsg → dismiss cmd returned |

Closes #21