### PR TITLE
Add optimistic state updates and spinner feedback for EC2 mutations

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Only **AWS** is supported at this time. Other cloud providers may be added in th
 | Service                    | Status      | Description                                                                                                                        |
 | -------------------------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------- |
 | [S3](services/aws/s3.md)   | Implemented | Browse buckets, navigate objects, preview/download files, copy/move, versioning, presigned URLs, create/delete buckets and objects |
-| [EC2](services/aws/ec2.md) | Implemented | Browse instances, view instance details, color-coded state, copy instance ID, SSM session connect                                  |
+| [EC2](services/aws/ec2.md) | Implemented | Browse instances, view details, start/stop/reboot/terminate, SSM session connect, color-coded state                                |
 
 ## Tech Stack
 
@@ -181,7 +181,7 @@ task test              # run all unit + integration tests
 task test:integration  # run integration tests against LocalStack
 ```
 
-Tests use [testify](https://github.com/stretchr/testify) for assertions and mocking, and [teatest v2](https://github.com/charmbracelet/x/tree/main/exp/teatest) for interaction-level tests that exercise the full BubbleTea program lifecycle. A shared `MockS3Service` in `internal/aws/awstest/` enables testing views without AWS credentials.
+Tests use [testify](https://github.com/stretchr/testify) for assertions and mocking, and [teatest v2](https://github.com/charmbracelet/x/tree/main/exp/teatest) for interaction-level tests that exercise the full BubbleTea program lifecycle. Shared mocks (`MockS3Service`, `MockEC2Service`) in `internal/aws/awstest/` enable testing views without AWS credentials.
 
 ## Architecture & Patterns
 
@@ -190,8 +190,8 @@ LazyCloud follows the [Elm Architecture](https://guide.elm-lang.org/architecture
 ### Layer Separation
 
 ```
-internal/aws/           S3Service interface + SDK implementation. No UI imports.
-internal/aws/awstest/   Shared testify mock for S3Service (used by view and app tests).
+internal/aws/           Service interfaces (S3Service, EC2Service) + SDK implementations. No UI imports.
+internal/aws/awstest/   Shared testify mocks for service interfaces (used by view and app tests).
 internal/views/         Bubble Tea models. Calls AWS layer via tea.Cmd. Handles input and rendering.
 internal/ui/            Reusable components (table, picker, toast, etc.). Not tied to any AWS service.
 internal/app/           Root model — message router, layout compositor, view factory, side panel.

--- a/internal/ui/icons.go
+++ b/internal/ui/icons.go
@@ -40,7 +40,7 @@ func StateColor(state string) string {
 		return lipgloss.NewStyle().Foreground(t.StateRunning).Render(IconRunning.Icon() + " " + state)
 	case "stopped", "terminated", "deleted":
 		return lipgloss.NewStyle().Foreground(t.StateStopped).Render(IconStopped.Icon() + " " + state)
-	case "pending", "starting", "stopping", "creating":
+	case "pending", "starting", "stopping", "shutting-down", "creating":
 		return lipgloss.NewStyle().Foreground(t.StatePending).Render(IconPending.Icon() + " " + state)
 	default:
 		return state

--- a/internal/views/ec2_list.go
+++ b/internal/views/ec2_list.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"charm.land/bubbles/v2/table"
 	tea "charm.land/bubbletea/v2"
@@ -29,6 +30,8 @@ type ec2SSMSessionFinishedMsg struct {
 	instanceName string
 	err          error
 }
+
+type ec2DelayedRefreshMsg struct{}
 
 type ec2InstanceMutatedMsg struct {
 	action     string // "started", "stopped", "rebooted", "terminated"
@@ -139,7 +142,10 @@ func (e *EC2List) Update(m tea.Msg) (tea.Model, tea.Cmd) {
 			id := e.pendingInstanceID
 			switch m.Value {
 			case "Start":
-				return e, e.startInstance(id)
+				ts := transitionalState("Start")
+				e.setInstanceState(id, ts)
+				e.spinner.Show("starting " + id + "...")
+				return e, tea.Batch(e.spinner.Tick(), e.startInstance(id))
 			case "Stop", "Reboot", "Terminate":
 				e.pendingAction = m.Value
 				action := m.Value
@@ -160,31 +166,48 @@ func (e *EC2List) Update(m tea.Msg) (tea.Model, tea.Cmd) {
 			return e, nil
 		}
 		id := e.pendingInstanceID
+		action := e.pendingAction
 		e.pendingInstanceID = ""
+		e.pendingAction = ""
+		if ts := transitionalState(action); ts != "" {
+			e.setInstanceState(id, ts)
+			e.spinner.Show(ts + " " + id + "...")
+		}
 		switch m.Action {
 		case "ec2_stop":
-			return e, e.stopInstance(id)
+			return e, tea.Batch(e.spinner.Tick(), e.stopInstance(id))
 		case "ec2_reboot":
-			return e, e.rebootInstance(id)
+			return e, tea.Batch(e.spinner.Tick(), e.rebootInstance(id))
 		case "ec2_terminate":
-			return e, e.terminateInstance(id)
+			return e, tea.Batch(e.spinner.Tick(), e.terminateInstance(id))
 		}
 		return e, nil
 
 	case ec2InstanceMutatedMsg:
 		if m.err != nil {
+			e.spinner.Hide()
 			e.err = m.err
 			return e, func() tea.Msg {
 				return msg.ToastError(m.action + " failed: " + m.err.Error())
 			}
 		}
-		e.loading = true
-		e.spinner.Show("Refreshing instances...")
+		// Delay refresh to give AWS time to register the state transition.
+		// Without this, DescribeInstances may return the old state and
+		// overwrite the optimistic update.
+		e.spinner.Show("Waiting for state change...")
 		action := m.action
 		id := m.instanceID
-		return e, tea.Batch(e.spinner.Tick(), e.fetchInstances(), func() tea.Msg {
+		delayedRefresh := func() tea.Msg {
+			time.Sleep(2 * time.Second)
+			return ec2DelayedRefreshMsg{}
+		}
+		return e, tea.Batch(e.spinner.Tick(), delayedRefresh, func() tea.Msg {
 			return msg.ToastSuccess("Instance " + action + ": " + id)
 		})
+
+	case ec2DelayedRefreshMsg:
+		e.spinner.Show("Refreshing instances...")
+		return e, tea.Batch(e.spinner.Tick(), e.fetchInstances())
 
 	case ec2SSMSessionFinishedMsg:
 		if m.err != nil {
@@ -375,6 +398,32 @@ func (e *EC2List) findInstance(id string) *aws.Instance {
 	return nil
 }
 
+// setInstanceState optimistically updates an instance's state in the local
+// data and rebuilds the table so the UI reflects the change immediately.
+func (e *EC2List) setInstanceState(id, state string) {
+	if inst := e.findInstance(id); inst != nil {
+		inst.State = state
+	}
+	rows, sortKeys := e.buildRows(e.instances)
+	e.table.SetRowsWithSortKeys(rows, sortKeys)
+}
+
+// transitionalState returns the EC2 transitional state for a given action.
+func transitionalState(action string) string {
+	switch action {
+	case "Start":
+		return "pending"
+	case "Stop":
+		return "stopping"
+	case "Reboot":
+		return "pending"
+	case "Terminate":
+		return "shutting-down"
+	default:
+		return ""
+	}
+}
+
 func (e *EC2List) actionsForState(state string) []string {
 	switch state {
 	case "stopped":
@@ -457,7 +506,8 @@ func (e *EC2List) buildRows(instances []aws.Instance) ([]table.Row, []table.Row)
 
 func (e *EC2List) View() tea.View {
 	var content string
-	if e.loading {
+	if e.loading && len(e.instances) == 0 {
+		// Initial load — spinner only
 		content = "\n  " + e.spinner.View()
 	} else if e.err != nil {
 		content = "\n  " + ui.ErrorStyle.Render("Error: "+e.err.Error())
@@ -467,7 +517,11 @@ func (e *EC2List) View() tea.View {
 			content = e.filter.View() + "\n" + content
 		}
 		filtered, total := e.table.RowCount()
-		content += fmt.Sprintf("\n %d/%d instances", filtered, total)
+		status := fmt.Sprintf("\n %d/%d instances", filtered, total)
+		if e.spinner.Visible() {
+			status += "  " + e.spinner.View()
+		}
+		content += status
 	}
 	return tea.NewView(content)
 }

--- a/internal/views/ec2_list_test.go
+++ b/internal/views/ec2_list_test.go
@@ -130,7 +130,7 @@ func TestEC2List_TerminateTriggersConfirm(t *testing.T) {
 	assert.Equal(t, "ec2_terminate", confirm.Action)
 }
 
-func TestEC2List_StartExecutesImmediately(t *testing.T) {
+func TestEC2List_StartExecutesWithOptimisticUpdate(t *testing.T) {
 	view, mockSvc := newTestEC2List()
 	loadInstances(view, []aws.Instance{testStoppedInstance})
 	view.pendingInstanceID = "i-stopped"
@@ -140,13 +140,26 @@ func TestEC2List_StartExecutesImmediately(t *testing.T) {
 	_, cmd := view.Update(ui.PickerResultMsg{ID: "action", Selected: 0, Value: "Start"})
 	require.NotNil(t, cmd)
 
-	// Execute the command — it should call StartInstance
+	// Verify optimistic state update happened immediately
+	inst := view.findInstance("i-stopped")
+	require.NotNil(t, inst)
+	assert.Equal(t, "pending", inst.State, "instance state should be optimistically set to pending")
+
+	// Verify spinner is showing
+	assert.True(t, view.spinner.Visible())
+
+	// Execute the batch — one of the cmds calls StartInstance
+	// (tea.Batch returns a BatchMsg containing the cmds)
 	result := cmd()
-	mutated, ok := result.(ec2InstanceMutatedMsg)
-	require.True(t, ok, "expected ec2InstanceMutatedMsg, got %T", result)
-	assert.Equal(t, "started", mutated.action)
-	assert.Equal(t, "i-stopped", mutated.instanceID)
-	assert.NoError(t, mutated.err)
+	batchMsgs, ok := result.(tea.BatchMsg)
+	require.True(t, ok, "expected tea.BatchMsg, got %T", result)
+
+	// Execute each cmd in the batch to trigger the mock
+	for _, batchCmd := range batchMsgs {
+		if batchCmd != nil {
+			batchCmd()
+		}
+	}
 	mockSvc.AssertCalled(t, "StartInstance", mock.Anything, "i-stopped")
 }
 


### PR DESCRIPTION
## Summary

Improves the user experience when performing EC2 instance mutations (start/stop/reboot/terminate) by providing immediate visual feedback instead of a blank gap between action and result.

## Before

1. User confirms action
2. **Nothing visible** for 2-5 seconds while API call completes
3. Toast + full refresh (which could show stale state)

## After

1. User confirms action
2. **Instantly**: instance state changes to yellow pending icon (e.g., "◌ stopping") + spinner appears in status line ("stopping i-abc123...")
3. API call returns → toast shown → spinner changes to "Waiting for state change..."
4. 2-second delay → "Refreshing instances..." → real state from AWS loaded

## Changes

### Optimistic state update (`internal/views/ec2_list.go`)
- `setInstanceState()` — updates an instance's state in-place and rebuilds the table immediately
- `transitionalState()` — maps actions to AWS transitional states: Start→pending, Stop→stopping, Reboot→pending, Terminate→shutting-down
- Applied before API call (Start) or after confirmation (Stop/Reboot/Terminate)

### Spinner alongside table
- During initial load: spinner replaces the table (no data to show)
- During mutations: spinner appears in the status line next to the instance count, table stays visible
- Progression: "stopping i-abc123..." → "Waiting for state change..." → "Refreshing instances..."

### Delayed refresh
- After the API returns, waits 2 seconds before calling `DescribeInstances`
- Prevents AWS from returning stale pre-transition state that overwrites the optimistic update
- Uses `ec2DelayedRefreshMsg` with `time.Sleep` in a `tea.Cmd`

### State colors (`internal/ui/icons.go`)
- Added `shutting-down` to the pending state color case (EC2's transitional state for terminating instances)

### Documentation (`README.md`)
- Updated EC2 description to mention start/stop/reboot/terminate
- Updated layer separation to mention EC2Service alongside S3Service
- Updated testing section to mention MockEC2Service

Closes #23