### PR TITLE
Clean up tabbed detail panel: remove duplicate title and refine layout

### DIFF
--- a/internal/ui/contentview.go
+++ b/internal/ui/contentview.go
@@ -364,6 +364,12 @@ func (cv ContentView) View() string {
 	header := titleText + "  " + formatBadge + posInfo + modeInfo + yankInfo
 
 	if cv.embedded {
+		// Drop title (tab bar already shows it); hide format badge for plain text
+		if cv.format != FormatText {
+			header = formatBadge + posInfo + modeInfo + yankInfo
+		} else {
+			header = posInfo + modeInfo + yankInfo
+		}
 		return header + "\n" + cv.viewport.View()
 	}
 


### PR DESCRIPTION
## Summary

Fixes #52. The tabbed detail panel showed redundant information — the active tab title appeared twice (once in the tab bar, once in the ContentView header), and the "text" format badge added noise for plain text tabs.

**Before:**
```
1:Info  2:JSON  3:Tags          ← tab bar
Info  text  Ln 1/15  100%       ← title repeated, "text" badge is noise
```

**After:**
```
1:Info  2:JSON  3:Tags          ← tab bar shows active tab
Ln 1/15  100%                   ← position only for text tabs
```

For structured format tabs (JSON, YAML, markdown, etc.), the format badge is preserved since it provides useful context:
```
1:Info  2:JSON  3:Tags
json  Ln 1/20  100%             ← format badge shown for non-text
```

This builds on the `embedded` flag added in #58 — when a ContentView is inside a TabbedPanel, the header is now streamlined to avoid duplicating what the tab bar already communicates.

Visual mode indicator and yank feedback are unaffected. Standalone ContentView (used in narrow terminal fallback) retains the full header with title and format badge.

## Test plan

- [x] EC2 detail panel: Info tab header shows `Ln 1/15  100%` (no title, no "text" badge)
- [x] EC2 detail panel: JSON tab header shows `json  Ln 1/20  100%` (format badge visible)
- [x] EC2 detail panel: Tags tab header shows `Ln 1/5  100%` (no title, no "text" badge)
- [x] S3 file preview (markdown): header shows `markdown  Ln 1/10  100%`
- [x] Visual mode (`V`) and yank (`y`) feedback still appear in header
- [ ] Narrow terminal fallback (standalone content view): full header unchanged