### PR TITLE
Fix global keys not working when side panel is focused

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -303,11 +303,48 @@ func (m Model) Update(teaMsg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 
+		// Global keys — work regardless of focus state
+		switch msg.String() {
+		case "ctrl+c":
+			return m, tea.Quit
+		case "q":
+			if m.panelOpen {
+				m.closePanel()
+				return m, nil
+			}
+			if m.nav.Depth() <= 1 {
+				return m, tea.Quit
+			}
+			m.nav.Pop()
+			return m, nil
+		case "T":
+			m.showThemePicker()
+			return m, nil
+		case "P":
+			m.showProfilePicker()
+			return m, nil
+		case "R":
+			m.showRegionPicker()
+			return m, nil
+		case "W":
+			m.showModePicker()
+			return m, nil
+		case "L":
+			eventlog.Debug(eventlog.CatUI, "Event log opened")
+			cmd := m.pushView(views.NewEventLog())
+			return m, cmd
+		case ":":
+			m.commandBar.Show(registry.CommandBarEntries(), m.width)
+			return m, nil
+		case "?":
+			hints := m.collectAllKeyHints()
+			m.help.Show(hints, m.width, m.height)
+			return m, nil
+		}
+
 		// Panel-focused key handling
 		if m.panelOpen && m.panelFocused && m.panel != nil {
 			switch msg.String() {
-			case "ctrl+c":
-				return m, tea.Quit
 			case "esc":
 				m.closePanel()
 				return m, nil
@@ -333,46 +370,12 @@ func (m Model) Update(teaMsg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 
+		// Context-specific esc when panel is not focused
 		switch msg.String() {
-		case "ctrl+c":
-			return m, tea.Quit
-		case "q":
-			if m.panelOpen {
-				m.closePanel()
-				return m, nil
-			}
-			if m.nav.Depth() <= 1 {
-				return m, tea.Quit
-			}
-			m.nav.Pop()
-			return m, nil
 		case "esc":
-			// Delegate esc to child first — it may need to dismiss a filter
+			// Delegate to child — it may need to dismiss a filter
 			cmd := m.nav.UpdateCurrent(teaMsg)
 			return m, cmd
-		case "T":
-			m.showThemePicker()
-			return m, nil
-		case "P":
-			m.showProfilePicker()
-			return m, nil
-		case "R":
-			m.showRegionPicker()
-			return m, nil
-		case "W":
-			m.showModePicker()
-			return m, nil
-		case "L":
-			eventlog.Debug(eventlog.CatUI, "Event log opened")
-			cmd := m.pushView(views.NewEventLog())
-			return m, cmd
-		case ":":
-			m.commandBar.Show(registry.CommandBarEntries(), m.width)
-			return m, nil
-		case "?":
-			hints := m.collectAllKeyHints()
-			m.help.Show(hints, m.width, m.height)
-			return m, nil
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fixes #63. Global keys (`:`, `?`, `T`, `P`, `R`, `W`, `L`, `q`) were swallowed by the panel-focused `default:` handler, which forwards all unhandled keys to the panel component.

Reorders the key dispatch so global keys are handled first, then panel-specific keys, then view-specific forwarding. The `esc` key remains context-specific (closes panel when focused, delegates to child view otherwise).

A proper refactor to the idiomatic `key.Binding` pattern is tracked in #68.

## Test plan

- [x] Focus panel → `:` opens command bar
- [x] Focus panel → `?` opens help overlay
- [x] Focus panel → `T` opens theme picker
- [x] Focus panel → `P`/`R`/`W`/`L` all work
- [x] Focus panel → `q` closes panel
- [x] Panel j/k/V/y/h/l/w/e still route to panel correctly
- [x] `esc` on panel still closes panel
- [x] `esc` on main view still delegates to child (e.g., dismisses filter)
- [x] `go test ./...` passes