### PR TITLE
Auto-highlight top suggestion in command bar

### DIFF
--- a/internal/ui/commandbar.go
+++ b/internal/ui/commandbar.go
@@ -165,7 +165,9 @@ func (c CommandBar) Update(msg tea.Msg) (CommandBar, tea.Cmd) {
 				c.rebuildFiltered()
 			} else if c.selected >= 0 && c.selected < len(c.filtered)-1 {
 				c.selected++
-			} else if c.selected == -1 && len(c.filtered) > 0 {
+			} else if c.selected == -1 && len(c.filtered) > 1 {
+				c.selected = 1 // skip implicit top highlight
+			} else if c.selected == -1 && len(c.filtered) == 1 {
 				c.selected = 0
 			}
 			return c, nil
@@ -248,10 +250,16 @@ func (c CommandBar) ViewSuggestions() string {
 		limit = maxSuggestions
 	}
 
+	// Default to top match when no manual selection (matches Enter behavior)
+	effectiveSelected := c.selected
+	if effectiveSelected < 0 && len(c.filtered) > 0 {
+		effectiveSelected = 0
+	}
+
 	var b strings.Builder
 	for i := 0; i < limit; i++ {
 		entry := c.commands[c.filtered[i]]
-		if i == c.selected {
+		if i == effectiveSelected {
 			b.WriteString(indicatorSelected + selectedNameStyle.Render(entry.Name) + selectedDescStyle.Render(entry.Description))
 		} else {
 			b.WriteString(indicatorNormal + nameStyle.Render(entry.Name) + descStyle.Render(entry.Description))

--- a/internal/ui/commandbar_test.go
+++ b/internal/ui/commandbar_test.go
@@ -116,11 +116,10 @@ func TestCommandBarTabCompletesSelectedSuggestion(t *testing.T) {
 	c := NewCommandBar()
 	c.Show(testCommands(), 120)
 
-	// Type "ec", then Down to select ec2/amis, then Tab
+	// Type "ec", then Down to select ec2/amis (skips implicit top highlight), then Tab
 	c, _ = c.Update(tea.KeyPressMsg{Code: 'e', Text: "e"})
 	c, _ = c.Update(tea.KeyPressMsg{Code: 'c', Text: "c"})
-	c, _ = c.Update(tea.KeyPressMsg{Code: tea.KeyDown})  // select ec2
-	c, _ = c.Update(tea.KeyPressMsg{Code: tea.KeyDown})  // select ec2/amis
+	c, _ = c.Update(tea.KeyPressMsg{Code: tea.KeyDown}) // select ec2/amis (first Down skips implicit ec2)
 	c, _ = c.Update(tea.KeyPressMsg{Code: tea.KeyTab})
 
 	assert.Equal(t, "ec2/amis", c.input)
@@ -207,8 +206,7 @@ func TestCommandBarEnterResolvesSelectedSuggestion(t *testing.T) {
 	c, _ = c.Update(tea.KeyPressMsg{Code: 'e', Text: "e"})
 	c, _ = c.Update(tea.KeyPressMsg{Code: 'c', Text: "c"})
 
-	// Down arrow to select second match ("ec2/amis")
-	c, _ = c.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	// Down arrow to select second match ("ec2/amis") — first Down skips implicit top highlight
 	c, _ = c.Update(tea.KeyPressMsg{Code: tea.KeyDown})
 	assert.Equal(t, 1, c.selected)
 


### PR DESCRIPTION
## Summary

Fixes #64. The command bar now highlights the top filtered suggestion by default when typing, showing the `▸` indicator and bold styling. This communicates which command Enter will execute without requiring the user to press Down first.

When `selected == -1` (no arrow key navigation), the rendering treats index 0 as the effective selection. This matches the Enter resolution logic from #50 which already executes `filtered[0]` in this case.

Arrow key navigation still overrides to highlight the manually selected row.

## Test plan

- [x] Type `:the` → top suggestion "theme" has `▸` indicator and bold styling
- [x] Press Down → selection moves to second item, top loses highlight
- [x] Press Up back → highlight returns to top
- [x] Type more characters → highlight stays on top match as list filters
- [x] `go test ./...` passes