### PR TITLE
Fix dialog padding and table border to match design system

### DIFF
--- a/internal/ui/confirm.go
+++ b/internal/ui/confirm.go
@@ -119,7 +119,7 @@ func (c Confirm) View() string {
 	box := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(t.Error).
-		Padding(1, 3)
+		Padding(0, 1)
 
 	return box.Render(content)
 }

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -112,7 +112,7 @@ func (h HelpOverlay) View() string {
 	box := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(t.Primary).
-		Padding(1, 3).
+		Padding(0, 1).
 		Width(h.boxWidth())
 
 	return box.Render(header.String() + h.viewport.View() + footer)

--- a/internal/ui/picker.go
+++ b/internal/ui/picker.go
@@ -233,7 +233,7 @@ func (p Picker) View() string {
 	box := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(t.Primary).
-		Padding(1, 3)
+		Padding(0, 1)
 
 	return box.Render(b.String())
 }

--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -45,7 +45,7 @@ func NewTable(columns []table.Column, rows []table.Row) Table {
 	theme := ActiveTheme
 	st := table.DefaultStyles()
 	st.Header = st.Header.
-		BorderStyle(lipgloss.NormalBorder()).
+		BorderStyle(lipgloss.RoundedBorder()).
 		BorderForeground(theme.Secondary).
 		BorderBottom(true).
 		Bold(true).


### PR DESCRIPTION
## Summary

Fixes #72. Aligns 4 components with the visual design system documented in #66.

**Dialog padding** — Picker, confirm, and help dialogs used `Padding(1, 3)` (1 line vertical, 3 chars horizontal). Changed to `Padding(0, 1)` per DESIGN_SYSTEM.md §5 spacing standards. This tightens the dialogs and makes them consistent.

**Table border** — Table header separator used `NormalBorder()` (square corners `┌┐└┘`). Changed to `RoundedBorder()` (rounded corners `╭╮╰╯`) per §4 "RoundedBorder everywhere — it's the app's visual signature."

## Test plan

- [ ] Open picker (`:` → select command) — tighter padding, same layout
- [ ] Open help (`?`) — tighter padding
- [ ] Trigger confirm dialog (delete action in RW mode) — tighter padding
- [ ] Table header separator uses rounded corners
- [ ] Verify across 2 themes
- [ ] `go test ./...` passes