### PR TITLE
Standardize toast durations and fix stuck toast bug

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -321,8 +321,7 @@ func (m Model) Update(teaMsg tea.Msg) (tea.Model, tea.Cmd) {
 			m.showThemePicker()
 			return m, nil
 		case "P":
-			m.showProfilePicker()
-			return m, nil
+			return m, m.showProfilePicker()
 		case "R":
 			m.showRegionPicker()
 			return m, nil
@@ -417,8 +416,7 @@ func (m Model) executeCommand(input string) (Model, tea.Cmd) {
 		m.showRegionPicker()
 		return m, nil
 	case "profile":
-		m.showProfilePicker()
-		return m, nil
+		return m, m.showProfilePicker()
 	default:
 		_, toastCmd := m.toasts.Add("Unknown command: "+input, ui.ToastError, 0)
 		return m, toastCmd
@@ -575,11 +573,11 @@ var awsRegions = []string{
 	"af-south-1",
 }
 
-func (m *Model) showProfilePicker() {
+func (m *Model) showProfilePicker() tea.Cmd {
 	profiles := aws.ListProfiles()
 	if len(profiles) == 0 {
-		m.toasts.Add("No profiles found in ~/.aws/config", ui.ToastError, 0)
-		return
+		_, cmd := m.toasts.Add("No profiles found in ~/.aws/config", ui.ToastError, 0)
+		return cmd
 	}
 
 	current := m.config.AWS.Profile
@@ -594,6 +592,7 @@ func (m *Model) showProfilePicker() {
 		options = append(options, ui.PickerOption{Label: label, Value: p})
 	}
 	m.picker.Show("profile", "Select Profile", options, currentIdx)
+	return nil
 }
 
 func (m Model) applyProfile(profile string) (Model, tea.Cmd) {

--- a/internal/ui/toast.go
+++ b/internal/ui/toast.go
@@ -44,10 +44,22 @@ func NewToastManager() ToastManager {
 	return ToastManager{maxVisible: 3}
 }
 
+// defaultDuration returns a level-appropriate duration for toasts.
+func defaultDuration(level ToastLevel) time.Duration {
+	switch level {
+	case ToastError:
+		return 6 * time.Second
+	case ToastSuccess:
+		return 3 * time.Second
+	default:
+		return 4 * time.Second
+	}
+}
+
 // Add creates a new toast and returns its ID and a dismiss command.
 func (tm *ToastManager) Add(text string, level ToastLevel, duration time.Duration) (int, tea.Cmd) {
 	if duration == 0 {
-		duration = 4 * time.Second
+		duration = defaultDuration(level)
 	}
 
 	id := tm.nextID


### PR DESCRIPTION
## Summary

Fixes #79. Two issues with toast notifications:

### 1. Level-appropriate default durations

All toasts previously defaulted to 4 seconds regardless of level. Now:
- **Error**: 6 seconds (user needs time to read error details)
- **Info**: 4 seconds
- **Success**: 3 seconds (quick confirmation, doesn't need to linger)

### 2. Fix stuck "No profiles found" toast

`showProfilePicker()` called `m.toasts.Add()` but discarded the returned dismiss command. The toast was created with a duration, but the `ToastDismissMsg` never reached the Bubble Tea runtime, so the toast persisted until the next `Update()` call (which only happens on user input). Changed `showProfilePicker()` to return `tea.Cmd` so the dismiss timer propagates correctly.

## Test plan

- [x] Press `P` with no AWS profiles configured → error toast appears and auto-dismisses after 6s
- [x] Switch theme (`T`) → success toast dismisses after 3s
- [x] Switch region (`R`) → success toast dismisses after 3s
- [x] Unknown command → error toast dismisses after 6s
- [x] `go test ./...` passes