### PR TITLE
Fix misleading help overlay footer hints

### DIFF
--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -103,7 +103,7 @@ func (h HelpOverlay) View() string {
 	}
 	header.WriteString("\n\n")
 
-	footer := "\n" + s.Muted.Render("type to filter  ↑/↓ scroll  ? close  esc close")
+	footer := "\n" + s.Muted.Render("type to filter  ? close  esc close")
 
 	box := s.DialogBorder.Width(h.boxWidth())
 


### PR DESCRIPTION
Closes #85

## Summary

- Replace `j/k scroll` with `type to filter  ↑/↓ scroll` in the help overlay footer
- j/k type into the filter like any other printable character — only arrow keys scroll the viewport

## Test plan

- [x] Open help overlay with `?`, verify footer reads `type to filter  ↑/↓ scroll  ? close  esc close`
- [x] Confirm typing letters filters the list (not scrolls)
- [x] Confirm ↑/↓ arrow keys scroll the viewport