### PR TITLE
Fix region/profile switch losing current view and stale SQS data

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -865,6 +865,7 @@ func (m Model) applyProfile(profile string) (Model, tea.Cmd) {
 	m.awsClient = awsClient
 	m.s3 = aws.NewS3Service(awsClient)
 	m.ec2 = aws.NewEC2Service(awsClient)
+	m.sqs = aws.NewSQSService(awsClient)
 
 	// Remember the active service view before resetting navigation
 	returnTo := m.topLevelViewID()
@@ -954,6 +955,7 @@ func (m Model) applyRegion(region string) (Model, tea.Cmd) {
 	m.awsClient = awsClient
 	m.s3 = aws.NewS3Service(awsClient)
 	m.ec2 = aws.NewEC2Service(awsClient)
+	m.sqs = aws.NewSQSService(awsClient)
 
 	// Remember the active service view before resetting navigation
 	returnTo := m.topLevelViewID()
@@ -1222,6 +1224,12 @@ func (m Model) topLevelViewID() string {
 		return "ami_list"
 	case strings.HasPrefix(id, "s3"):
 		return "s3_list"
+	case strings.HasPrefix(id, "sqs"):
+		return "sqs_queues"
+	case strings.HasPrefix(id, "sg"):
+		return "sg_list"
+	case strings.HasPrefix(id, "vpc"), strings.HasPrefix(id, "subnet"):
+		return "vpc_list"
 	default:
 		return ""
 	}


### PR DESCRIPTION
## Summary

- Recreate `m.sqs` in `applyRegion()` and `applyProfile()` so SQS views use the new AWS client instead of showing stale data from the old region/profile
- Add missing `topLevelViewID()` cases for `sqs`, `sg`, `vpc`, and `subnet` so the app stays on the current service view after switching instead of dropping to the home screen

## Follow-on

#195 — refactor both functions to share a single client rebuild path so new services can't be missed again.

## Test plan

- [x] Switch region while viewing EC2 — stays on EC2, data refreshes
- [x] Switch region while viewing SQS — stays on SQS, data refreshes
- [x] Switch region while viewing VPCs/SGs — stays on correct view
- [x] Switch profile — same behavior, all services refreshed
- [x] Back navigation still works after region switch

Closes #194