### PR TITLE
Fix ANSI-styled cell values breaking table row highlight

### DIFF
--- a/internal/ui/icons.go
+++ b/internal/ui/icons.go
@@ -1,6 +1,11 @@
 package ui
 
-import "charm.land/lipgloss/v2"
+import (
+	"fmt"
+	"image/color"
+
+	"github.com/charmbracelet/x/ansi"
+)
 
 // ServiceIcon holds a Nerd Font icon and a Unicode fallback.
 type ServiceIcon struct {
@@ -35,16 +40,33 @@ var (
 	IconPending = ServiceIcon{Nerd: "\U000f0e4e", Fallback: "◌"} // nf-md-clock
 )
 
+// FgRender applies a foreground color without a full ANSI reset.
+// It uses \x1b[39m (default foreground) instead of \x1b[m (reset all),
+// so any background set by an outer style (e.g., table row selection)
+// is preserved. Use this instead of lipgloss.Render for table cell values.
+func FgRender(c color.Color, s string) string {
+	return ansi.Style{}.ForegroundColor(c).String() + s + "\x1b[39m"
+}
+
+// CountColor returns a styled count string — warning-colored when non-zero, plain when zero.
+func CountColor(count int) string {
+	s := fmt.Sprintf("%d", count)
+	if count == 0 {
+		return s
+	}
+	return FgRender(ActiveTheme.Warning, s)
+}
+
 // StateColor returns a styled state string with the appropriate color and icon.
 func StateColor(state string) string {
 	t := ActiveTheme
 	switch state {
 	case "running", "available", "active":
-		return lipgloss.NewStyle().Foreground(t.StateRunning).Render(IconRunning.Icon() + " " + state)
+		return FgRender(t.StateRunning, IconRunning.Icon()+" "+state)
 	case "stopped", "terminated", "deleted", "failed", "unavailable":
-		return lipgloss.NewStyle().Foreground(t.StateStopped).Render(IconStopped.Icon() + " " + state)
+		return FgRender(t.StateStopped, IconStopped.Icon()+" "+state)
 	case "pending", "starting", "stopping", "shutting-down", "creating":
-		return lipgloss.NewStyle().Foreground(t.StatePending).Render(IconPending.Icon() + " " + state)
+		return FgRender(t.StatePending, IconPending.Icon()+" "+state)
 	default:
 		return state
 	}

--- a/internal/views/sqs_queues.go
+++ b/internal/views/sqs_queues.go
@@ -727,9 +727,13 @@ func (s *SQSQueues) buildRows(queues []aws.Queue) ([]table.Row, []table.Row) {
 	rows := make([]table.Row, 0, len(queues))
 	sortKeys := make([]table.Row, 0, len(queues))
 	for _, q := range queues {
-		msgCount := fmt.Sprintf("%d", q.ApproximateMessageCount)
-		inFlight := fmt.Sprintf("%d", q.ApproximateInFlightCount)
-		delayed := fmt.Sprintf("%d", q.ApproximateDelayedCount)
+		msgCount := ui.CountColor(q.ApproximateMessageCount)
+		inFlight := ui.CountColor(q.ApproximateInFlightCount)
+		delayed := ui.CountColor(q.ApproximateDelayedCount)
+
+		rawMsg := fmt.Sprintf("%d", q.ApproximateMessageCount)
+		rawFlight := fmt.Sprintf("%d", q.ApproximateInFlightCount)
+		rawDelayed := fmt.Sprintf("%d", q.ApproximateDelayedCount)
 
 		created := ""
 		if !q.CreatedTimestamp.IsZero() {
@@ -744,13 +748,13 @@ func (s *SQSQueues) buildRows(queues []aws.Queue) ([]table.Row, []table.Row) {
 		switch s.widthTier {
 		case ui.TierNarrow:
 			rows = append(rows, table.Row{q.Name, msgCount})
-			sortKeys = append(sortKeys, table.Row{q.Name, msgCount})
+			sortKeys = append(sortKeys, table.Row{q.Name, rawMsg})
 		case ui.TierMedium:
 			rows = append(rows, table.Row{q.Name, q.Type, msgCount, inFlight, delayed})
-			sortKeys = append(sortKeys, table.Row{q.Name, q.Type, msgCount, inFlight, delayed})
+			sortKeys = append(sortKeys, table.Row{q.Name, q.Type, rawMsg, rawFlight, rawDelayed})
 		default:
 			rows = append(rows, table.Row{q.Name, q.Type, msgCount, inFlight, delayed, dlq, created})
-			sortKeys = append(sortKeys, table.Row{q.Name, q.Type, msgCount, inFlight, delayed, dlq, created})
+			sortKeys = append(sortKeys, table.Row{q.Name, q.Type, rawMsg, rawFlight, rawDelayed, dlq, created})
 		}
 	}
 	return rows, sortKeys


### PR DESCRIPTION
## Summary

- Replace `lipgloss.Render()` with a new `ui.FgRender()` helper for table cell values — uses `\x1b[39m` (foreground-only reset) instead of `\x1b[m` (full reset), preserving the selected row's background color across styled cells
- Re-enable color-coded message counts in SQS queue list (warning-colored non-zero counts) with separate plain sort keys

## Root Cause

`ansi.Style.Styled()` wraps text with a simple prefix + suffix reset (`\x1b[m`). When the bubbles table applies the Selected row style and the row contains cell-level lipgloss styling, the inner `\x1b[m` resets all attributes — killing the outer background for the rest of the row.

## Test plan

- [x] SQS: non-zero message counts render in yellow, selected row highlight extends to full width
- [x] EC2: state column colors (running/stopped/pending) still render correctly with full-width highlight
- [x] VPC/Subnet: state colors work correctly
- [x] Verify at narrow, medium, and wide terminal widths
- [x] Column sorting still works correctly on styled count columns

Closes #162